### PR TITLE
`executeFunction`: throw error when passing native functions

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 import {chrome} from 'jest-chrome';
-import {describe, it, assert} from 'vitest';
-import {getTabsByUrl} from './index.js';
+import {describe, it, assert, expect} from 'vitest';
+import {executeFunction, getTabsByUrl} from './index.js';
 
 const tab1 = {
 	id: 1,
@@ -64,5 +64,11 @@ describe('getTabsByUrl', () => {
 			[],
 			'It should exclude tabs with URLs matching `excludeMatches`, even if it’s the only match',
 		);
+	});
+});
+
+describe('executeFunction', () => {
+	it('should throw with native functions', async () => {
+		await expect(executeFunction(1, Date)).rejects.toMatchInlineSnapshot('[TypeError: Native functions need to be wrapped first, like `executeFunction(1, () => alert(1))`]');
 	});
 });

--- a/index.ts
+++ b/index.ts
@@ -49,11 +49,17 @@ function castArray<A = unknown>(possibleArray: A | A[]): A[] {
 
 type MaybeArray<X> = X | X[];
 
+const nativeFunction = /^function \w+\(\) {[\n\s]+\[native code][\n\s]+}/;
+
 export async function executeFunction<Fn extends (...args: any[]) => unknown>(
 	target: number | Target,
 	function_: Fn,
 	...args: unknown[]
 ): Promise<ReturnType<Fn>> {
+	if (nativeFunction.test(String(function_))) {
+		throw new TypeError('Native functions need to be wrapped first, like `executeFunction(1, () => alert(1))`');
+	}
+
 	const {frameId, tabId} = castTarget(target);
 
 	if (gotScripting) {


### PR DESCRIPTION
- Closes https://github.com/fregante/webext-content-scripts/issues/6