### PR TITLE
Replace `browser` types with `chrome`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
   Lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
       - name: install
@@ -23,7 +23,7 @@ jobs:
   Build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: install
         run: npm ci || npm install
       - name: build

--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,6 @@
 import chromeP from 'webext-polyfill-kinda';
-import type {ExtensionTypes} from 'webextension-polyfill';
 import {patternToRegex} from 'webext-patterns';
-import type {ContentScript} from './types.js';
+import type {ContentScript, ExtensionFileOrCode, RunAt} from './types.js';
 
 const gotScripting = Boolean(globalThis.chrome?.scripting);
 
@@ -92,12 +91,8 @@ interface InjectionDetails {
 	frameId?: number;
 	matchAboutBlank?: boolean;
 	allFrames?: boolean;
-	runAt?: ExtensionTypes.RunAt;
-	files: string [] | Array<{
-		code: string;
-	} | {
-		file: string;
-	}>;
+	runAt?: RunAt;
+	files: string [] | ExtensionFileOrCode[];
 }
 
 // eslint-disable-next-line @typescript-eslint/naming-convention -- It follows the native naming

--- a/package.json
+++ b/package.json
@@ -43,17 +43,16 @@
 		}
 	},
 	"dependencies": {
-		"webext-patterns": "^1.2.0",
-		"webext-polyfill-kinda": "^0.10.0"
+		"webext-patterns": "^1.3.0",
+		"webext-polyfill-kinda": "^1.0.0"
 	},
 	"devDependencies": {
 		"@sindresorhus/tsconfig": "^3.0.1",
-		"@types/chrome": "^0.0.206",
-		"@types/jest": "^29.2.5",
-		"@types/webextension-polyfill": "^0.9.2",
+		"@types/chrome": "^0.0.210",
+		"@types/jest": "^29.4.0",
 		"jest-chrome": "^0.8.0",
 		"typescript": "^4.9.4",
-		"vitest": "^0.27.1",
+		"vitest": "^0.28.3",
 		"xo": "^0.53.1"
 	}
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,15 +1,21 @@
-import type {ExtensionTypes} from 'webextension-polyfill';
+export type ExtensionFileOrCode = {
+	code: string;
+} | {
+	file: string;
+};
+
+export type RunAt = 'document_start' | 'document_end' | 'document_idle';
 
 export interface ContentScript {
 	/**
 	 * The list of CSS files to inject
 	 */
-	css?: string[] | ExtensionTypes.ExtensionFileOrCode[];
+	css?: string[] | ExtensionFileOrCode[];
 
 	/**
 	 * The list of JS files to inject
 	 */
-	js?: string[] | ExtensionTypes.ExtensionFileOrCode[];
+	js?: string[] | ExtensionFileOrCode[];
 
 	/**
 	 * Prefer `allFrames`
@@ -36,10 +42,10 @@ export interface ContentScript {
 	/**
 	 * Prefer `runAt`
 	 */
-	run_at?: ExtensionTypes.RunAt;
+	run_at?: RunAt;
 
 	/**
 	 * The soonest that the JavaScript or CSS will be injected into the tab. Defaults to "document_idle".
 	 */
-	runAt?: ExtensionTypes.RunAt;
+	runAt?: RunAt;
 }


### PR DESCRIPTION
- Follows https://github.com/fregante/webext-polyfill-kinda/pull/5

`webext-content-scripts`’s types explicitly imported `webextension-polyfill` even though it's not declared in `dependencies`

This PR drops this dependencies and uses just the `chrome` global internally. `@types/chrome` isn't required for the user at all at this point. **This isn't a breaking change** for that reason.