### PR TITLE
`executeFunction`: support `iframe[srcdoc]` and `about:blank`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -76,6 +76,7 @@ export async function executeFunction<Fn extends (...args: any[]) => unknown>(
 
 	const [result] = await chromeP.tabs.executeScript(tabId, {
 		code: `(${function_.toString()})(...${JSON.stringify(args)})`,
+		matchAboutBlank: true, // Needed for `srcdoc` frames; doesn't hurt normal pages
 		frameId,
 	}) as [ReturnType<Fn>];
 


### PR DESCRIPTION
Reported in https://github.com/pixiebrix/pixiebrix-extension/issues/7300#issuecomment-1882809312

https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/executeScript#matchaboutblank

`scripting.executeFunction()` doesn't mention about:blank, so we'll see how MV3 deals with it.