### PR TITLE
Avoid duplicate injections

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2,6 +2,8 @@ import chromeP from 'webext-polyfill-kinda';
 import {patternToRegex} from 'webext-patterns';
 import type {ContentScript, ExtensionFileOrCode, RunAt} from './types.js';
 
+export * from './types.js';
+
 const gotScripting = Boolean(globalThis.chrome?.scripting);
 
 interface AllFramesTarget {
@@ -44,6 +46,25 @@ function castArray<A = unknown>(possibleArray: A | A[]): A[] {
 	}
 
 	return [possibleArray];
+}
+
+function normalizeFiles(files: InjectionDetails['files'], seen: string[] = []): ExtensionFileOrCode[] {
+	return files
+		.map(file => typeof file === 'string' ? {file} : file)
+		.filter(content => {
+			if ('code' in content) {
+				return true;
+			}
+
+			const file = typeof content === 'string' ? content : content.file;
+			if (seen.includes(file)) {
+				console.debug(`Duplicated file not injected: ${file}`);
+				return false;
+			}
+
+			seen.push(file);
+			return true;
+		});
 }
 
 type MaybeArray<X> = X | X[];
@@ -93,7 +114,7 @@ interface InjectionDetails {
 	matchAboutBlank?: boolean;
 	allFrames?: boolean;
 	runAt?: RunAt;
-	files: string [] | ExtensionFileOrCode[];
+	files: string[] | ExtensionFileOrCode[];
 }
 
 // eslint-disable-next-line @typescript-eslint/naming-convention -- It follows the native naming
@@ -109,12 +130,10 @@ export async function insertCSS(
 
 	{ignoreTargetErrors}: InjectionOptions = {},
 ): Promise<void> {
-	const everyInsertion = Promise.all(files.map(async content => {
-		if (typeof content === 'string') {
-			content = {file: content};
-		}
-
+	const normalizedFiles = normalizeFiles(files);
+	const everyInsertion = Promise.all(normalizedFiles.map(async content => {
 		if (gotScripting) {
+			// One file at a time, according to the types
 			return chrome.scripting.insertCSS({
 				target: {
 					tabId,
@@ -164,7 +183,7 @@ export async function executeScript(
 
 	{ignoreTargetErrors}: InjectionOptions = {},
 ): Promise<void> {
-	const normalizedFiles = files.map(file => typeof file === 'string' ? {file} : file);
+	const normalizedFiles = normalizeFiles(files);
 	if (gotScripting) {
 		assertNoCode(normalizedFiles);
 		const injection = chrome.scripting.executeScript({
@@ -243,25 +262,30 @@ async function injectContentScriptInSpecificTarget(
 	scripts: MaybeArray<ContentScript>,
 	options: InjectionOptions = {},
 ): Promise<void> {
-	const injections = castArray(scripts).flatMap(script => [
-		insertCSS({
-			tabId,
-			frameId,
-			allFrames,
-			files: script.css ?? [],
-			matchAboutBlank: script.matchAboutBlank ?? script.match_about_blank,
-			runAt: script.runAt ?? script.run_at as RunAt,
-		}, options),
+	const seen: string[] = [];
+	const injections = castArray(scripts).flatMap(script => {
+		const css = normalizeFiles(script.css ?? [], seen);
+		const js = normalizeFiles(script.js ?? [], seen);
+		return [
+			css.length > 0 && insertCSS({
+				tabId,
+				frameId,
+				allFrames,
+				files: css,
+				matchAboutBlank: script.matchAboutBlank ?? script.match_about_blank,
+				runAt: script.runAt ?? script.run_at as RunAt,
+			}, options),
 
-		executeScript({
-			tabId,
-			frameId,
-			allFrames,
-			files: script.js ?? [],
-			matchAboutBlank: script.matchAboutBlank ?? script.match_about_blank,
-			runAt: script.runAt ?? script.run_at as RunAt,
-		}, options),
-	]);
+			js.length > 0 && executeScript({
+				tabId,
+				frameId,
+				allFrames,
+				files: js,
+				matchAboutBlank: script.matchAboutBlank ?? script.match_about_blank,
+				runAt: script.runAt ?? script.run_at as RunAt,
+			}, options),
+		];
+	});
 
 	await Promise.all(injections);
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,10 @@
 	"license": "MIT",
 	"author": "Federico Brigante <me@fregante.com> (https://fregante.com)",
 	"type": "module",
-	"exports": "./index.js",
+	"exports": {
+		".": "./index.js",
+		"./types": "./types.d.ts"
+	},
 	"main": "./index.js",
 	"types": "./index.d.ts",
 	"files": [

--- a/package.json
+++ b/package.json
@@ -21,10 +21,7 @@
 	"license": "MIT",
 	"author": "Federico Brigante <me@fregante.com> (https://fregante.com)",
 	"type": "module",
-	"exports": {
-		".": "./index.js",
-		"./types": "./types.d.ts"
-	},
+	"exports": "./index.js",
 	"main": "./index.js",
 	"types": "./index.d.ts",
 	"files": [


### PR DESCRIPTION
Scripts and CSS files are duduplicated within a single injection call, so `executeScript({js: ['a.js', 'a.js']})` or `injectContentScript` with multiple files.

Successive files will just be ignored, even if their setup is different (e.g. `run_at`)